### PR TITLE
Update log.sh

### DIFF
--- a/log.sh
+++ b/log.sh
@@ -76,9 +76,16 @@ LSLOG () {
   # if no message was passed, read it from STDIN
   local _MSG
   [[ $# -ne 0 ]] && _MSG="$@" || _MSG="$(cat)"
-  echo -ne "$_LS_LEVEL_BEGIN$OUTPUT " >> "$LS_OUTPUT"
-  echo -n  "$_MSG"                    >> "$LS_OUTPUT"
-  echo -e "$_LS_LEVEL_END" >> "$LS_OUTPUT"
+  if [ "$LS_OUTPUT" = "/dev/stdout" ]
+  then
+    echo -ne "$_LS_LEVEL_BEGIN$OUTPUT " #>> "$LS_OUTPUT"
+    echo -n  "$_MSG"                    #>> "$LS_OUTPUT"
+    echo -e "$_LS_LEVEL_END" #>> "$LS_OUTPUT"
+  else
+    echo -ne "$_LS_LEVEL_BEGIN$OUTPUT " >> "$LS_OUTPUT"
+    echo -n  "$_MSG"                    >> "$LS_OUTPUT"
+    echo -e "$_LS_LEVEL_END" >> "$LS_OUTPUT"
+  fi
 }
 
 shopt -s expand_aliases


### PR DESCRIPTION
Addresses Issue 3 by preventing ">> /dev/stdout" from being used and instead just letting bash handle where to send the output if $LS_OUTPUT is /dev/stdout